### PR TITLE
Use map/dictionary to store the colours instead using many "if"s, added green colour and .bat script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Compilation process on Windows relies on [MingW](https://www.mingw-w64.org). Fol
 - After the compilation  has finished, press ```CTRL + \` ``` and run the following commands:  
 `cp -r C:\Users\[USERNAME]\Desktop\starfetch.exe`, `C:\MingW\bin; cd C:\MingW\bin`, `.\starfetch.exe`
 
+### If on `Windows` you can compile `starfetch` and start it from the `starfetch.bat` script. If you want to start the program with specific constellation and/or different color -- open up `starfetch.bat` script and edit `C:\MingW\bin\starfetch.exe -c blue` -- it get spawned with random constellation and blue color.
+
 Alternative versions:
 - [K1ngst0m](https://github.com/K1ngst0m/starfetch): starfetch doesn't depend on the files in `/usr/local/share/starfetch/`
 

--- a/src/starfetch.bat
+++ b/src/starfetch.bat
@@ -3,7 +3,7 @@
 @ECHO OFF
 :BEGIN
 CLS
-COPY main.exe C:\MingW\bin\starfetch.exe
+COPY starfetch.exe C:\MingW\bin\starfetch.exe
 :loop
 C:\MingW\bin\starfetch.exe -c blue
 PAUSE

--- a/src/starfetch.bat
+++ b/src/starfetch.bat
@@ -1,0 +1,10 @@
+:TOP
+@CLS
+@ECHO OFF
+:BEGIN
+CLS
+COPY main.exe C:\MingW\bin\starfetch.exe
+:loop
+C:\MingW\bin\starfetch.exe -c blue
+PAUSE
+GOTO loop

--- a/src/starfetch.cpp
+++ b/src/starfetch.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <regex>
 #include <list>
+#include <map>
 //#include <unistd.h> for getpid()
 #include "include/json.hpp"
 
@@ -112,11 +113,10 @@ int main(int argc, char *argv[])
 
 static void setColor(string color)
 {
-  static const string reqColor[] = {"\033[1;30m", "\033[1;37m", "\033[1;36m", "\033[1;35m", "\033[1;33m", "\033[1;31m", "\033[1;34m"};
-  static const string colorKeyword[] = {"black", "white", "cyan", "magenta", "yellow", "red", "blue"};
-  for (unsigned short int x = 0U; x < 7U; x++) {
-    if (color == colorKeyword[x]) {
-      REQUESTED_COLOR = reqColor[x];
+  static map<string, string> colorKeyword = { {"black", "\033[1;30m"}, {"white", "\033[1;37m"}, {"cyan", "\033[1;36m"}, {"magenta", "\033[1;35m"}, {"yellow", "\033[1;33m"}, {"red", "\033[1;31m"}, {"blue", "\033[1;34m"}};
+  for (const auto &[key, val] : colorKeyword) {
+    if (color == key) {
+      REQUESTED_COLOR = val;
       break;
     }
   }

--- a/src/starfetch.cpp
+++ b/src/starfetch.cpp
@@ -32,7 +32,7 @@ static string SEP = "\\";
 static string path = "/usr/local/share/starfetch/";
 static string SEP = "/";
 #endif // _WIN32
-string directories[2] = {"constellations", "norse-constellations"}; // array that holds all the directory paths. Consider using a multidimensional array to hold the directory name and also the "nickname" to be used for <type> when using "starfetch -n <type> <constellation>"
+static string directories[2] = {"constellations", "norse-constellations"}; // array that holds all the directory paths. Consider using a multidimensional array to hold the directory name and also the "nickname" to be used for <type> when using "starfetch -n <type> <constellation>"
 static string REQUESTED_COLOR = "\033[1;37m"; // white color
 
 int main(int argc, char *argv[])
@@ -112,8 +112,8 @@ int main(int argc, char *argv[])
 
 static void setColor(string color)
 {
-  static const char *reqColor[] = {"\033[1;30m", "\033[1;37m", "\033[1;36m", "\033[1;35m", "\033[1;33m", "\033[1;31m", "\033[1;34m"};
-  static const char *colorKeyword[] = {"black", "white", "cyan", "magenta", "yellow", "red", "blue"};
+  static const string reqColor[] = {"\033[1;30m", "\033[1;37m", "\033[1;36m", "\033[1;35m", "\033[1;33m", "\033[1;31m", "\033[1;34m"};
+  static const string colorKeyword[] = {"black", "white", "cyan", "magenta", "yellow", "red", "blue"};
   for (unsigned short int x = 0U; x < 7U; x++) {
     if (color == colorKeyword[x]) {
       REQUESTED_COLOR = reqColor[x];

--- a/src/starfetch.cpp
+++ b/src/starfetch.cpp
@@ -31,9 +31,8 @@ static string SEP = "\\";
 #else
 static string path = "/usr/local/share/starfetch/";
 static string SEP = "/";
-string directories[2] = {"constellations", "norse-constellations"}; // array that holds all the directory paths. Consider using a multidimensional array to hold the directory name and also the "nickname" to be used for <type> when using "starfetch -n <type> <constellation>"
 #endif // _WIN32
-
+string directories[2] = {"constellations", "norse-constellations"}; // array that holds all the directory paths. Consider using a multidimensional array to hold the directory name and also the "nickname" to be used for <type> when using "starfetch -n <type> <constellation>"
 static string REQUESTED_COLOR = "\033[1;37m"; // white color
 
 int main(int argc, char *argv[])
@@ -113,20 +112,14 @@ int main(int argc, char *argv[])
 
 static void setColor(string color)
 {
-  if (color == "black")
-    REQUESTED_COLOR = "\033[1;30m";
-  else if (color == "white")
-    REQUESTED_COLOR = "\033[1;37m";
-  else if (color == "cyan")
-    REQUESTED_COLOR = "\033[1;36m";
-  else if (color == "magenta")
-    REQUESTED_COLOR = "\033[1;35m";
-  else if (color == "yellow")
-    REQUESTED_COLOR = "\033[1;33m";
-  else if (color == "red")
-    REQUESTED_COLOR = "\033[1;31m";
-  else if (color == "blue")
-    REQUESTED_COLOR = "\033[1;34m";
+  static const char *reqColor[] = {"\033[1;30m", "\033[1;37m", "\033[1;36m", "\033[1;35m", "\033[1;33m", "\033[1;31m", "\033[1;34m"};
+  static const char *colorKeyword[] = {"black", "white", "cyan", "magenta", "yellow", "red", "blue"};
+  for (unsigned short int x = 0U; x < 7U; x++) {
+    if (color == colorKeyword[x]) {
+      REQUESTED_COLOR = reqColor[x];
+      break;
+    }
+  }
 }
 
 static inline void PrintConst(string &pathc)

--- a/src/starfetch.cpp
+++ b/src/starfetch.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 
 static void setColor(string color)
 {
-  static map<string, string> colorKeyword = { {"black", "\033[1;30m"}, {"white", "\033[1;37m"}, {"cyan", "\033[1;36m"}, {"magenta", "\033[1;35m"}, {"yellow", "\033[1;33m"}, {"red", "\033[1;31m"}, {"blue", "\033[1;34m"}};
+  static map<string, string> colorKeyword = { {"black", "\033[1;30m"}, {"white", "\033[1;37m"}, {"cyan", "\033[1;36m"}, {"magenta", "\033[1;35m"}, {"yellow", "\033[1;33m"}, {"green", "\033[1;32m"}, {"red", "\033[1;31m"}, {"blue", "\033[1;34m"}};
   for (const auto &[key, val] : colorKeyword) {
     if (color == key) {
       REQUESTED_COLOR = val;


### PR DESCRIPTION
Hi there,

Just saw that `starfetch` doesn't build on Windows and the offending line is - https://github.com/Haruno19/starfetch/blob/d0aab03f5c6ca791e759201021eb77e89e0aa20f/src/starfetch.cpp#L34

Added ~~2 arrays~~ a map/dictionary with the available + requested colours and one `for` loop to use single `if` statement to compare the requested colour and match it against that.

edit:


Added `green` colour as well.

Added `.bat` script for the Window users, so the end user can modify the `.bat` script by hand if he/she wants to.

![Screenshot 2025-03-12 191836](https://github.com/user-attachments/assets/b098bb47-d6e2-4fca-80c2-8c4552b0acaa)

And in the above picture the constellations are the same by running `starfetch` 2 times.