### PR TITLE
Updated help texts to include green color option

### DIFF
--- a/GUI/mainwindow.cpp
+++ b/GUI/mainwindow.cpp
@@ -197,6 +197,8 @@ static void setColor(string color)
         REQUESTED_COLOR = "<font color=\"magenta\">";
     else if (color == "yellow")
         REQUESTED_COLOR = "<font color=\"yellow\">";
+    else if (color == "green")
+        REQUESTED_COLOR = "<font color=\"green\">";
     else if (color == "red")
         REQUESTED_COLOR = "<font color=\"red\">";
     else if (color == "blue")

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ starfetch [OPTION] [ARGUMENT]
     -n      Shows the selected constellation.
     -r      Shows a random constellation.
     -l      Prints the list of all the available constellations.
-    -c      Use given color such as: black, white, cyan, magenta, yellow, red, blue.
+    -c      Use given color such as: black, white, cyan, magenta, yellow, green, red, blue.
 
 If launched with no arguments, the behaviour is the same as with '-c white -r'.
 

--- a/res/help_message.txt
+++ b/res/help_message.txt
@@ -5,7 +5,7 @@ Usage: starfetch [OPTION] [ARGUMENT]
     -n      Shows the selected constellation.
     -r      Shows a random constellation.
     -l      Prints the list of all the available constellations.
-    -c      Use given color such as: black, white, cyan, magenta, yellow, red, blue.
+    -c      Use given color such as: black, white, cyan, magenta, yellow, green, red, blue.
 
 If launched with no arguments, the behaviour is the same as with '-c white -r'.
 

--- a/src/starfetch.cpp
+++ b/src/starfetch.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
         {
           if (argc == 2)
           {
-            cout << "Available colors are: black, white, cyan, magenta, yellow, red, blue" << endl;
+            cout << "Available colors are: black, white, cyan, magenta, yellow, green, red, blue" << endl;
             return EXIT_SUCCESS;
           }
           else if (argc == 3 || argc == 4)


### PR DESCRIPTION
The various help texts (e.g. `starfetch -h`, `starfetch -c`) didn't show green as a color option. Now they do!

This is my first FOSS contribution! Please let me know if there's something I've done wrong. :)